### PR TITLE
Bump etl 20.32.1 -> 20.37.2

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -49,6 +49,6 @@ class OBCSoftwareRecipe(ConanFile):
         cmake.build()
 
     def requirements(self):
-        self.requires("etl/20.32.1")
+        self.requires("etl/20.37.2")
         self.requires("logger/1.0")
         self.requires("ecss-services/1.0")


### PR DESCRIPTION
As discussed internally. This matches logger's ETL version as of 2024-06-10, fixing conan conflict resolution.